### PR TITLE
feat(targets): function to map targets->oil recipe name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,19 +17,20 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.0.4', require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0', require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0', require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
-  gem 'concurrent-ruby', '< 1.2.0',                     require: false
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "voxpupuli-puppet-lint-plugins", '>= 3.0', require: false
+  gem 'concurrent-ruby', '< 1.2.0', require: false
+  gem 'rspec-puppet-utils', require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/lib/puppet/functions/newrelic_installer/targets_to_recipes.rb
+++ b/lib/puppet/functions/newrelic_installer/targets_to_recipes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# https://github.com/puppetlabs/puppet-specifications/blob/master/language/func-api.md#the-4x-api
+Puppet::Functions.create_function(:"newrelic_installer::targets_to_recipes") do
+  dispatch :targets_to_recipes do
+    param 'Tuple', :a
+    return_type 'String' # list of comma-separated recipes
+  end
+  def targets_to_recipes(targets)
+    recipes = []
+    valid_recipe_mappings = { 'infrastructure' => 'infrastructure-agent-installer' }
+
+    targets.each do |target|
+      if valid_recipe_mappings.key?(target)
+        recipes << valid_recipe_mappings[target]
+      else
+        Warning.warn("Warning: Valid recipe not found for target '#{target}', skipping\n")
+      end
+    end
+
+    recipes.join(',')
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,13 +33,11 @@ class newrelic_installer::install (
   Integer $install_timeout_seconds = 600,
 ) {
   # Validate and transform friendly-recipe names to open-install-library formats
-  # TODO create a custom function to handle nice->oil lookups, return in comma-separate list for cli
-  if $targets.length() == 0 {
+  $recipes = newrelic_installer::targets_to_recipes($targets)
+  if $recipes.length() == 0 {
     fail('New Relic instrumentation target not provided')
-  } else {
-    $oil_recipe_names = ['infrastructure-agent-installer']
   }
-  $cli_recipe_arg = "-n ${oil_recipe_names.join(',')}"
+  $cli_recipe_arg = "-n ${recipes}"
 
   # Validate required environment variables
   $nr_api_key = $environment_variables['NEW_RELIC_API_KEY']

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -2,6 +2,16 @@
 
 require 'spec_helper'
 
+RSpec.shared_context 'targets_to_recipe_stub' do
+  let(:pre_condition) do
+    '
+    function newrelic_installer::targets_to_recipes(Tuple $arg) >> String {
+      return "valid_oil_recipe"
+    }
+    '
+  end
+end
+
 def required_vars
   {
     'targets' => ['some-valid-recipe-name'],
@@ -14,6 +24,7 @@ end
 
 describe 'newrelic_installer::install' do
   on_supported_os.each do |os, os_facts|
+    include_context 'targets_to_recipe_stub'
     context "installed and running newrelic-infra on #{os}" do
       let(:facts) { os_facts }
       let(:params) do

--- a/spec/functions/targets_to_recipes_spec.rb
+++ b/spec/functions/targets_to_recipes_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'newrelic_installer::targets_to_recipes' do
+  # single valid recipe
+  it { is_expected.to run.with_params(['infrastructure']).and_return('infrastructure-agent-installer') }
+  # valid and invalid
+  it { is_expected.to run.with_params(['infrastructure', 'nope']).and_return('infrastructure-agent-installer') }
+  # all invalid
+  it { is_expected.to run.with_params(['nope']).and_return('') }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ end
 
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
+require 'rspec-puppet-utils'
 
 require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
 


### PR DESCRIPTION
Added helper function to map target variables to open-install-library names.  Currently supporting the following:
`infrastructure` => `infrastructure-agent-installer`
`php` => `php-agent-installer`