### PR TITLE
Added dd-style testing against amazon and ubuntu linux for php apm

### DIFF
--- a/test/demo-deployer/packages/amazon/2/php/main.yml
+++ b/test/demo-deployer/packages/amazon/2/php/main.yml
@@ -1,0 +1,31 @@
+---
+# Update package manager
+- name: Update yum
+  shell: yum -y update
+  become: yes
+
+# Download/install PHP from amazon's package manager
+- name: Install PHP
+  shell: "amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2"
+  become: yes
+
+- name: Install other prereqs
+  ansible.builtin.yum:
+    pkg:
+      - httpd
+      - mariadb
+      - mariadb-server
+    state: present
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../common/php/templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/demo-deployer/packages/amazon/2/puppet/main.yml
+++ b/test/demo-deployer/packages/amazon/2/puppet/main.yml
@@ -26,4 +26,4 @@
     owner: root
     group: root
     state: link
-
+  become: yes

--- a/test/demo-deployer/packages/amazon/2022/puppet/main.yml
+++ b/test/demo-deployer/packages/amazon/2022/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/centos/7/puppet/main.yml
+++ b/test/demo-deployer/packages/centos/7/puppet/main.yml
@@ -26,3 +26,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/centos/8/puppet/main.yml
+++ b/test/demo-deployer/packages/centos/8/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/common/php/templates/install-wordpress.sh
+++ b/test/demo-deployer/packages/common/php/templates/install-wordpress.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Install wp-cli
+curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+php wp-cli.phar --info
+chmod +x wp-cli.phar
+mv wp-cli.phar /usr/local/bin/wp
+
+# Set up Wordpress
+mkdir -p /wordpress
+rm -rf /wordpress/*
+cd /wordpress
+
+echo "<?php phpinfo(); ?>"| tee test.php
+
+# Ensure /usr/local/bin is on the path as it doesn't appear
+# to be, by default, on the Linux 2 image.
+if [[ ":$PATH:" != *:/usr/local/bin:* ]]; then
+	export PATH=$PATH:/usr/local/bin
+fi
+
+# If on RedHat based distro, assume we are using mariadb, and
+# that it needs to be started post package installation.
+if [ $(which yum) ]; then
+	service mariadb start
+fi
+
+mysql -u root -e \
+"GRANT ALL ON *.* TO 'wp_user'@'localhost' IDENTIFIED BY 'wp_password'; \
+FLUSH PRIVILEGES;"
+
+echo WP core download.
+wp core download --allow-root
+
+echo WP core config.
+wp core config --allow-root \
+               --dbhost=localhost \
+               --dbname=wordpress \
+               --dbuser=wp_user \
+               --dbpass=wp_password
+
+echo WP db create.
+wp db create --allow-root
+
+echo WP core install.
+wp core install --allow-root \
+                --url={{ ip }} \
+                --title="PHP Wordpress Test App" \
+                --admin_name=admin \
+            --admin_password=admin \
+            --admin_email=admin@example.com
+
+if [ $(which nginx) ]; then
+	if [ -d /etc/nginx/sites-available ]; then
+		if [ ! -f /etc/nginx/sites-available/wordpress-site ]; then
+			echo Creating nginx wordpress-site config.
+			cp ~/templates/wordpress-site /etc/nginx/sites-available
+		fi
+		if [ ! -L /etc/nginx/sites-enabled/wordpress-site ]; then
+			echo Activating nginx wordpress-site config.
+			ln -s /etc/nginx/sites-available/wordpress-site /etc/nginx/sites-enabled/
+		fi
+		if [ -L /etc/nginx/sites-enabled/default ]; then
+			echo Disabling default nginx site config.
+			unlink /etc/nginx/sites-enabled/default
+		fi
+	else
+		sed -i -e "s/\/usr\/share\/nginx\/html/\/wordpress/" /etc/nginx/nginx.conf
+	fi
+	echo Restarting nginx.
+	systemctl restart nginx
+fi
+
+if [ $(which apache2) ]; then
+	SITE="wordpress"
+	if [[ $(dpkg -l php-fpm) ]]; then
+		echo "Using PHP FPM variant of apache2 site config."
+		SITE="wordpress-fpm"
+
+		echo Enabling proxy_fcgi.
+		a2enmod proxy_fcgi
+	fi
+	if [ ! -f /etc/apache2/sites-available/$SITE.conf ]; then
+		echo Creating apache2 wordpress site config.
+		cp ~/templates/$SITE.conf /etc/apache2/sites-available
+	fi
+	echo Enabling apache2 wordpress site.
+	a2ensite $SITE
+
+	echo Disabling apache2 default site.
+	a2dissite 000-default
+
+	echo Enabling apache2 mod rewrite.
+	a2enmod rewrite
+	if [ -L /etc/apache2/sites-enabled/default ]; then
+		unlink /etc/apache2/sites-enabled/default
+	fi
+
+	echo Restarting apache2.
+	service apache2 reload
+fi
+
+# The presence of httpd indicates we are running on a Linux 2 host.
+# The FPM / no FPM decision is made via packages in this case.
+if [ $(which httpd) ]; then
+	cp ~/templates/wordpress-httpd.conf /etc/httpd/conf.d/
+	sed -i -e "s/DocumentRoot \"\/var\/www\/html/DocumentRoot \"\/wordpress/" /etc/httpd/conf/httpd.conf
+	service httpd restart
+fi

--- a/test/demo-deployer/packages/common/php/templates/wordpress-fpm.conf
+++ b/test/demo-deployer/packages/common/php/templates/wordpress-fpm.conf
@@ -1,0 +1,47 @@
+<VirtualHost *:80>
+    # The ServerName directive sets the request scheme, hostname and port that
+    # the server uses to identify itself. This is used when creating
+    # redirection URLs. In the context of virtual hosts, the ServerName
+    # specifies what hostname must appear in the request's Host: header to
+    # match this virtual host. For the default virtual host (this file) this
+    # value is not decisive as it is used as a last resort host regardless.
+    # However, you must set it for any further virtual host explicitly.
+    #ServerName www.example.com
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /wordpress
+
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+    <FilesMatch \.php>
+        SetHandler proxy:unix:/var/run/php/php7.2-fpm.sock|fcgi://localhost;
+    </FilesMatch>    
+</VirtualHost>
+
+<Directory /wordpress>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Order allow,deny
+    Require all granted
+    Allow from all
+</Directory>
+<Directory /wordpress/wp-content>
+    Options FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/demo-deployer/packages/common/php/templates/wordpress-httpd.conf
+++ b/test/demo-deployer/packages/common/php/templates/wordpress-httpd.conf
@@ -1,0 +1,14 @@
+<Directory /wordpress>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Order allow,deny
+    Require all granted
+    Allow from all
+</Directory>
+<Directory /wordpress/wp-content>
+    Options FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/demo-deployer/packages/common/php/templates/wordpress-site
+++ b/test/demo-deployer/packages/common/php/templates/wordpress-site
@@ -1,0 +1,25 @@
+server {
+        listen 80;
+        root /wordpress;
+        index index.php index.html index.htm index.nginx-debian.html;
+
+        location / {
+		try_files $uri $uri/ /index.php$is_args$args;
+		location = /favicon.ico { log_not_found off; access_log off; }
+		location = /robots.txt { log_not_found off; access_log off; allow all; }
+		location ~* \.(css|gif|ico|jpeg|jpg|js|png)$ {
+			expires max;
+			log_not_found off;
+		}
+        }
+
+        location ~ \.php$ {
+                include snippets/fastcgi-php.conf;
+                fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+        }
+
+        location ~ /\.ht {
+                deny all;
+        }
+}
+

--- a/test/demo-deployer/packages/common/php/templates/wordpress.conf
+++ b/test/demo-deployer/packages/common/php/templates/wordpress.conf
@@ -1,0 +1,45 @@
+<VirtualHost *:80>
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        #ServerName www.example.com
+
+        ServerAdmin webmaster@localhost
+        DocumentRoot /wordpress
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include conf-available/serve-cgi-bin.conf
+
+</VirtualHost>
+
+<Directory /wordpress>
+    Options FollowSymLinks
+    AllowOverride Limit Options FileInfo
+    DirectoryIndex index.php
+    Order allow,deny
+    Require all granted
+    Allow from all
+</Directory>
+<Directory /wordpress/wp-content>
+    Options FollowSymLinks
+    Order allow,deny
+    Allow from all
+</Directory>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/test/demo-deployer/packages/debian/10/puppet/main.yml
+++ b/test/demo-deployer/packages/debian/10/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/18/php/main.yml
+++ b/test/demo-deployer/packages/ubuntu/18/php/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install PHP and pre-reqs
+  apt:
+    pkg:
+      - libapache2-mod-php
+      - mysql-server
+      - mysql-client
+      - php-mysql
+    update_cache: yes
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../common/php/templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/18/puppet/main.yml
+++ b/test/demo-deployer/packages/ubuntu/18/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/20/php/main.yml
+++ b/test/demo-deployer/packages/ubuntu/20/php/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install PHP and pre-reqs
+  apt:
+    pkg:
+      - libapache2-mod-php
+      - mysql-server
+      - mysql-client
+      - php-mysql
+    update_cache: yes
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../common/php/templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/20/puppet/main.yml
+++ b/test/demo-deployer/packages/ubuntu/20/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/22/php/main.yml
+++ b/test/demo-deployer/packages/ubuntu/22/php/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install PHP and pre-reqs
+  apt:
+    pkg:
+      - libapache2-mod-php
+      - mysql-server
+      - mysql-client
+      - php-mysql
+    update_cache: yes
+  become: yes
+
+- template:
+    src: "{{ item }}"
+    dest: ~/templates/
+    mode: 0755
+  with_fileglob:
+    - ../../../common/php/templates/*
+  become: yes
+
+- shell:
+    cmd: ~/templates/install-wordpress.sh
+  become: yes

--- a/test/demo-deployer/packages/ubuntu/22/puppet/main.yml
+++ b/test/demo-deployer/packages/ubuntu/22/puppet/main.yml
@@ -29,3 +29,4 @@
     owner: root
     group: root
     state: link
+  become: yes

--- a/test/demo-deployer/setup/php/roles/configure/tasks/install-module/linux.yml
+++ b/test/demo-deployer/setup/php/roles/configure/tasks/install-module/linux.yml
@@ -1,0 +1,26 @@
+---
+- name: Find locally-built module tarball
+  shell: find /home/puppet-install/pkg -type f -iname "newrelic-newrelic_installer*tar.gz" -print -quit
+  register: puppet_tarball_location
+
+- name: Install locally-built module from tarball
+  shell: puppet module install {{ puppet_tarball_location.stdout }}
+  register: command_output
+
+- name: ensure manifests directory exists
+  file:
+    path: $HOME/.puppetlabs/etc/code/manifests
+    state: directory
+
+- name: Copy site.pp to localhost
+  template:
+    src: site.pp.j2
+    dest: $HOME/.puppetlabs/etc/code/manifests/site.pp
+
+
+- name: Apply newrelic-newrelic_installer module
+  shell: sudo puppet apply --modulepath=$HOME/.puppetlabs/etc/code/modules $HOME/.puppetlabs/etc/code/manifests/site.pp
+  register: apply_output
+
+- debug:
+    msg: "{{ apply_output.stdout }}"

--- a/test/demo-deployer/setup/php/roles/configure/tasks/install-module/templates/site.pp.j2
+++ b/test/demo-deployer/setup/php/roles/configure/tasks/install-module/templates/site.pp.j2
@@ -1,0 +1,8 @@
+class { 'newrelic_installer::install':
+  targets               => ["php"],
+  environment_variables => {
+    "NEW_RELIC_API_KEY"    => "{{ nr_api_key }}",
+    "NEW_RELIC_ACCOUNT_ID" => {{ nr_account_id }},
+    "NEW_RELIC_REGION"     => "{{ nr_region }}",
+  }
+}

--- a/test/demo-deployer/setup/php/roles/configure/tasks/main.yml
+++ b/test/demo-deployer/setup/php/roles/configure/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+# Install instrumentation target to be tested
+- name: Install PHP
+  include_tasks: ../../../../packages/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}/php/main.yml
+
+# Install dependencies (git, puppet, php)
+- name: Install git
+  include_tasks: ../../../../packages/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}/git/main.yml
+- name: Install puppet
+  include_tasks: ../../../../packages/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}/puppet/main.yml
+- name: Install puppet-development-kit
+  include_tasks: ../../../../packages/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}/puppet-development-kit/main.yml
+
+# Clone module repo and build locally
+- name: Clone puppet-install repository
+  ansible.builtin.git:
+    repo: https://github.com/newrelic/puppet-install.git
+    dest: /home/puppet-install
+#    TODO: test against your branch that is pushed to remote when running locally...
+#    version: chore/php-dd-test
+  become: true
+- name: Build newrelic-newrelic_installer using PDK
+  shell: |
+    cd /home/puppet-install
+    /usr/local/bin/pdk build --force
+  become: true
+
+# Instrument infra recipe via module
+- name: Installing newrelic_installer module
+  include_tasks: install-module/linux.yml
+  vars:
+    nr_api_key: "{{ newrelic_personal_api_key }}"
+    nr_account_id: "{{ newrelic_account_id }}"
+    nr_region: "{{ newrelic_region|upper }}"

--- a/test/demo-deployer/targets/php/amzn2-php.json
+++ b/test/demo-deployer/targets/php/amzn2-php.json
@@ -1,0 +1,43 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.small",
+      "ami_name": "amzn2-ami-hvm-2.0.????????.?-x86_64-gp2",
+      "user_name": "ec2-user"
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "amzn2_puppet-install_php",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/php/roles"
+      },
+      {
+        "id": "recipeValidation",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "params": {
+          "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
+        }
+      }
+    ]
+  }
+}

--- a/test/demo-deployer/targets/php/ubuntu18-php.json
+++ b/test/demo-deployer/targets/php/ubuntu18-php.json
@@ -1,0 +1,43 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "ubuntu18_puppet-install_php",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/php/roles"
+      },
+      {
+        "id": "recipeValidation",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "params": {
+          "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
+        }
+      }
+    ]
+  }
+}

--- a/test/demo-deployer/targets/php/ubuntu20-php.json
+++ b/test/demo-deployer/targets/php/ubuntu20-php.json
@@ -1,0 +1,43 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "ubuntu20_puppet-install_php",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/php/roles"
+      },
+      {
+        "id": "recipeValidation",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "params": {
+          "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
+        }
+      }
+    ]
+  }
+}

--- a/test/demo-deployer/targets/php/ubuntu22-php.json
+++ b/test/demo-deployer/targets/php/ubuntu22-php.json
@@ -1,0 +1,43 @@
+{
+  "global_tags": {
+    "owning_team": "virtuoso",
+    "Environment": "development",
+    "Department": "product",
+    "Product": "virtuoso"
+  },
+  "resources": [
+    {
+      "id": "host1",
+      "provider": "aws",
+      "type": "ec2",
+      "size": "t3.micro",
+      "ami_name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-2023????",
+      "user_name": "ubuntu"
+    }
+  ],
+  "instrumentations": {
+    "resources": [
+      {
+        "id": "ubuntu22_puppet-install_php",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/php/roles"
+      },
+      {
+        "id": "recipeValidation",
+        "resource_ids": [
+          "host1"
+        ],
+        "provider": "newrelic",
+        "source_repository": "https://github.com/newrelic/puppet-install",
+        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "params": {
+          "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
These are meant to run locally.  You will need to do the following to configure your local demo-deployer:

1.  clone this repo

2.  mount this repo in a demo-deployer container
`docker run -i -v /path/to/your/configs/:/mnt/deployer/configs/  -v /path/to/this/repo/puppet-install/:/mnt/deployer/puppet-install/ --entrypoint sh [ghcr.io/newrelic/deployer](http://ghcr.io/newrelic/deployer)`

3. update any tests using `source_repository` to use your docker mount via `local_source_path`.  This pertains to demo-deployer .json configs in the following locations

- /puppet-install/test/demo-deployer/targets/infrastructure/
- /puppet-install/test/demo-deployer/targets/php/

for example:
`     "provider": "newrelic",
        "source_repository": "https://github.com/newrelic/puppet-install",
        "deploy_script_path": "test/demo-deployer/setup/php/roles"
`
becomes
`     "provider": "newrelic",
        "local_source_path": "/mnt/deployer/puppet-install",
        "deploy_script_path": "/test/demo-deployer/setup/php/roles"
`        

4. run the tests.  These tests use NRQL to validate installations are reporting data to New Relic

