### PR TITLE
Enable PHP APM instrumentation via puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.bundle/
 /.idea/
 /.vagrant/
+/.ignore/
 /coverage/
 /bin/
 /doc/

--- a/lib/puppet/functions/newrelic_installer/targets_to_recipes.rb
+++ b/lib/puppet/functions/newrelic_installer/targets_to_recipes.rb
@@ -15,7 +15,8 @@ Puppet::Functions.create_function(:"newrelic_installer::targets_to_recipes") do
 
     valid_recipe_mappings = {
       'infrastructure' => 'infrastructure-agent-installer',
-      'logs' => 'logs-integration'
+      'logs' => 'logs-integration',
+      'php' => 'php-agent-installer'
     }
     requires_infrastructure_set = Set['logs']
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -70,7 +70,8 @@ class newrelic_installer::install (
   $skip_core = { 'NEW_RELIC_CLI_SKIP_CORE' => 1 }
 
   # transform environment_variables to cli argument (really an array of key=value)
-  $cli_envars = ($environment_variables + $proxy_envar + $nr_region + $skip_core).map |$key, $value| { "${key}=${value}" }
+  $cli_envars = ($environment_variables + $proxy_envar + $nr_region + $skip_core).map |$key, $value| { "${key}=${value}"
+  }
 
   # transform verbosity to cli argument
   if $verbosity != undef and downcase($verbosity) in ['debug', 'trace'] {
@@ -92,7 +93,7 @@ class newrelic_installer::install (
       remote_file { '/tmp/newrelic_cli_install.sh':
         ensure => present,
         source => 'https://download.newrelic.com/install/newrelic-cli/scripts/install.sh',
-        mode   => '777',
+        mode   => '511',
         proxy  => $proxy,
       }
       -> exec { 'install newrelic-cli':
@@ -108,16 +109,12 @@ class newrelic_installer::install (
         timeout     => $install_timeout_seconds,
         logoutput   => true,
       }
-      -> service { 'newrelic-infra':
-        ensure => 'running',
-        enable => 'true',
-      }
     }
     'windows': {
       remote_file { 'C:\Windows\TEMP\install.ps1':
         ensure => present,
         source => 'https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1',
-        mode   => '777',
+        mode   => '511',
         proxy  => $proxy,
       }
       -> exec { 'install newrelic-cli':
@@ -132,10 +129,6 @@ class newrelic_installer::install (
         environment => $cli_envars,
         timeout     => $install_timeout_seconds,
         logoutput   => true,
-      }
-      -> service { 'newrelic-infra':
-        ensure => 'running',
-        enable => 'true',
       }
     }
     default: {

--- a/spec/functions/targets_to_recipes_spec.rb
+++ b/spec/functions/targets_to_recipes_spec.rb
@@ -3,12 +3,15 @@
 require 'spec_helper'
 
 describe 'newrelic_installer::targets_to_recipes' do
-  # single valid recipe
+  # single valid recipe - infrastructure
   it { is_expected.to run.with_params(['infrastructure']).and_return('infrastructure-agent-installer') }
+  it { is_expected.to run.with_params(['php']).and_return('php-agent-installer') }
   # valid and invalid
   it { is_expected.to run.with_params(['infrastructure', 'nope']).and_return('infrastructure-agent-installer') }
   # all invalid
   it { is_expected.to run.with_params(['nope']).and_return('') }
   # infrastructure is missing
   it { is_expected.to run.with_params(['logs']).and_raise_error(Puppet::ParseError) }
+  # infrastructure is still missing
+  it { is_expected.to run.with_params(['php', 'logs']).and_raise_error(Puppet::ParseError) }
 end

--- a/test/demo-deployer/setup/php/roles/configure/tasks/main.yml
+++ b/test/demo-deployer/setup/php/roles/configure/tasks/main.yml
@@ -17,7 +17,7 @@
     repo: https://github.com/newrelic/puppet-install.git
     dest: /home/puppet-install
 #    TODO: test against your branch that is pushed to remote when running locally...
-#    version: chore/php-dd-test
+    version: feat/php-apm
   become: true
 - name: Build newrelic-newrelic_installer using PDK
   shell: |

--- a/test/demo-deployer/targets/infrastructure/amzn2-infra.json
+++ b/test/demo-deployer/targets/infrastructure/amzn2-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/amzn2022-infra.json
+++ b/test/demo-deployer/targets/infrastructure/amzn2022-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/centos7-infra.json
+++ b/test/demo-deployer/targets/infrastructure/centos7-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/centos8-infra.json
+++ b/test/demo-deployer/targets/infrastructure/centos8-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/debian10-infra.json
+++ b/test/demo-deployer/targets/infrastructure/debian10-infra.json
@@ -24,8 +24,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -33,8 +33,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/ubuntu18-infra.json
+++ b/test/demo-deployer/targets/infrastructure/ubuntu18-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago limit max"
         }

--- a/test/demo-deployer/targets/infrastructure/ubuntu20-infra.json
+++ b/test/demo-deployer/targets/infrastructure/ubuntu20-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/infrastructure/ubuntu22-infra.json
+++ b/test/demo-deployer/targets/infrastructure/ubuntu22-infra.json
@@ -23,8 +23,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/setup/infrastructure/roles"
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/setup/infrastructure/roles"
       },
       {
         "id": "recipeValidation",
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ProcessSample where hostname like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/php/amzn2-php.json
+++ b/test/demo-deployer/targets/php/amzn2-php.json
@@ -23,7 +23,7 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
+        "local_source_path": "/mnt/deployer/puppet-install",
         "deploy_script_path": "/test/demo-deployer/setup/php/roles"
       },
       {
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/php/ubuntu18-php.json
+++ b/test/demo-deployer/targets/php/ubuntu18-php.json
@@ -23,7 +23,7 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
+        "local_source_path": "/mnt/deployer/puppet-install",
         "deploy_script_path": "/test/demo-deployer/setup/php/roles"
       },
       {
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/php/ubuntu20-php.json
+++ b/test/demo-deployer/targets/php/ubuntu20-php.json
@@ -23,7 +23,7 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
+        "local_source_path": "/mnt/deployer/puppet-install",
         "deploy_script_path": "/test/demo-deployer/setup/php/roles"
       },
       {
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
         }

--- a/test/demo-deployer/targets/php/ubuntu22-php.json
+++ b/test/demo-deployer/targets/php/ubuntu22-php.json
@@ -23,7 +23,7 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
+        "local_source_path": "/mnt/deployer/puppet-install",
         "deploy_script_path": "/test/demo-deployer/setup/php/roles"
       },
       {
@@ -32,8 +32,8 @@
           "host1"
         ],
         "provider": "newrelic",
-        "source_repository": "https://github.com/newrelic/puppet-install",
-        "deploy_script_path": "test/demo-deployer/validate/roles",
+        "local_source_path": "/mnt/deployer/puppet-install",
+        "deploy_script_path": "/test/demo-deployer/validate/roles",
         "params": {
           "nrql_query": "select count(*) from ApplicationAgentContext where agent.language = 'php' and host like '%HOSTNAME%' since 8 minutes ago"
         }


### PR DESCRIPTION
Currently contains no functionality for applicationName, pending further discussion.  This functionality will instrument PHP applications using the name `PHP Application` based on:
```
class { 'newrelic_installer::install':
  targets               => ["php"],
  environment_variables => {
    "NEW_RELIC_API_KEY"    => "your-api-key",
    "NEW_RELIC_ACCOUNT_ID" => 1234567890,
    "NEW_RELIC_REGION"     => "your-nr-region"
  }
}
```

Basic unit tests cover the addition of this recipe: ` pdk test unit --verbose`