### PR TITLE
chore: Bumping powershell version to 6.0.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": "6.0.0"
+      "version_requirement": "6.0.1"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_installer",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "New Relic, Inc.",
   "summary": "Puppet module for installing New Relic integrations",
   "license": "Apache-2.0",


### PR DESCRIPTION
Updating the version from 6.0.0 to 6.0.1 as release to puppet forge has failed
https://github.com/newrelic/puppet-install/actions/runs/12667632359/job/35301438770#step:2:552
<img width="754" alt="Screenshot 2025-01-08 at 3 27 04 PM" src="https://github.com/user-attachments/assets/0ca2f8d8-3fd4-466d-b654-79b780be444d" />
