### PR TITLE
feat(region): add Japan (JP) region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class { 'newrelic_installer::install':
           environment_variables => {
             "NEW_RELIC_API_KEY"          => "<YOUR-NR-API-KEY>",
             "NEW_RELIC_ACCOUNT_ID"       => <YOUR-NR-ACCOUNT-ID>,
-            "NEW_RELIC_REGION"           => "<US|EU>",
+            "NEW_RELIC_REGION"           => "<US|EU|JP>",
             "NEW_RELIC_APPLICATION_NAME" => "<YOUR-PHP-APPLICATION-NAME>"
           }
 }
@@ -62,7 +62,7 @@ Supported values include:
 Hash of environment variables to set prior to execution.
 * `NEW_RELIC_API_KEY`: your New Relic API key **required*
 * `NEW_RELIC_ACCOUNT_ID`: your New Relic account id **required*
-* `NEW_RELIC_REGION`: your New Relic account's region (`US` or `EU`).  Defaults to `US` if not specified
+* `NEW_RELIC_REGION`: your New Relic account's region (`US`, `EU`, or `JP`).  Defaults to `US` if not specified
 * `NEW_RELIC_APPLICATION_NAME`: used by `'php'`. This config option sets the application name that data is reported under in APM. Defaults to `'PHP Application'` if not specified.
 #### `verbosity` _String_ (optional)
 Specifies command output verbosity

--- a/developer-guide.md
+++ b/developer-guide.md
@@ -67,7 +67,7 @@ class { 'newrelic_installer::install':
     environment_variables => {
         'NEW_RELIC_API_KEY'    => '<YOUR-NR-API-KEY>',
         'NEW_RELIC_ACCOUNT_ID' => <YOUR-NR-ACCOUNT-ID>,
-        'NEW_RELIC_REGION'     => 'US', # or 'EU' based on your account
+        'NEW_RELIC_REGION'     => 'US', # or 'EU' or 'JP' based on your account
     },
 }
 ```

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,7 +51,7 @@ class newrelic_installer::install (
   # Default region to US
   if $environment_variables['NEW_RELIC_REGION'] == undef
   or $environment_variables['NEW_RELIC_REGION'].length() == 0
-  or !(upcase($environment_variables['NEW_RELIC_REGION']) in ['US', 'EU', 'STAGING']) {
+  or !(upcase($environment_variables['NEW_RELIC_REGION']) in ['US', 'EU', 'JP', 'STAGING']) {
     $nr_region = { 'NEW_RELIC_REGION' => 'US' }
   } else {
     $nr_region = { 'NEW_RELIC_REGION' => "${upcase($environment_variables['NEW_RELIC_REGION'])}" }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -105,6 +105,23 @@ describe 'newrelic_installer::install' do
     end
   end
   on_supported_os.each do |os, os_facts|
+    context "installs using JP as region #{os}" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'targets' => ['infrastructure'],
+          'environment_variables' => {
+            'NEW_RELIC_API_KEY' => 'some-api-key',
+            'NEW_RELIC_ACCOUNT_ID' => 123,
+            'NEW_RELIC_REGION' => 'jp'
+          },
+        }
+      end
+
+      it { is_expected.to contain_exec('install newrelic instrumentation').with('environment' => %r{(.*)NEW_RELIC_REGION=JP(.*)}) }
+    end
+  end
+  on_supported_os.each do |os, os_facts|
     context "installs explicity pass US as region #{os}" do
       let(:facts) { os_facts }
       let(:params) do

--- a/test/demo-deployer/validate/roles/onafterstart/tasks/main.yml
+++ b/test/demo-deployer/validate/roles/onafterstart/tasks/main.yml
@@ -29,6 +29,11 @@
     newrelic_api_url_to_use: "api.eu.newrelic.com"
   when: newrelic_api_url is undefined and (newrelic_region|lower) == 'eu'
 
+- name: Configure nerdgraph calls to use JP url
+  set_fact:
+    newrelic_api_url_to_use: "api.jp.newrelic.com"
+  when: newrelic_api_url is undefined and (newrelic_region|lower) == 'jp'
+
 - name: Configure nerdgraph calls to use Staging url
   set_fact:
     newrelic_api_url_to_use: "staging-api.newrelic.com"


### PR DESCRIPTION
## Summary

Adds Japan (JP) to the allowed-region whitelist in `manifests/install.pp` so JP is no longer silently coerced to US. Updates README and developer-guide docs to advertise JP as a supported value.

Mirrors the existing EU spec context with a JP test (`spec/classes/install_spec.rb`) to assert that `NEW_RELIC_REGION=jp` is uppercased and forwarded as `NEW_RELIC_REGION=JP` to the install exec.

## Test plan

- [ ] `bundle exec rspec spec/classes/install_spec.rb` — new JP context passes alongside existing US/EU/invalid-region contexts.
- [ ] Manually run `puppet apply` with `NEW_RELIC_REGION => 'jp'` and confirm the env var reaches the install command as `JP`.