### PR TITLE
chore(version): bump to 0.5.10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_installer",
-  "version": "0.5.3",
+  "version": "0.5.10",
   "author": "New Relic, Inc.",
   "summary": "Puppet module for installing New Relic integrations",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bumps `metadata.json` from `0.5.3` to `0.5.10` so the next tag-driven release publishes to Puppet Forge under the correct version.

Required because the release workflow reads `metadata.json` to determine the version it pushes to Forge — without this bump, pushing tag `v0.5.10` would either republish `0.5.3` (already on Forge) or be rejected.

## Test plan

- [ ] Merge.
- [ ] Tag `v0.5.10` at the merge commit — release workflow publishes `0.5.10` to Puppet Forge.