### PR TITLE
chore: relax powershell pin and bump to 0.5.11

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_installer",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "author": "New Relic, Inc.",
   "summary": "Puppet module for installing New Relic integrations",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": "6.0.1"
+      "version_requirement": ">= 6.0.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary

Recovers the broken `v0.5.10` release and bumps to `0.5.11`.

The `v0.5.10` Release ([run #27267950063](https://github.com/newrelic/puppet-install/actions/runs/27267950063)) failed at the `publish module to forge.puppet.com` step:

```
pdk (ERROR): An error occured checking the module dependencies: ...
Checking metadata.json dependencies.
  puppetlabs/powershell (6.0.1) doesn't match 6.1.0
```

PDK's release-time dependency check resolves transitive dependencies and rejects the strict `"6.0.1"` pin because Forge currently ships `6.1.0`. Switched to a range, matching the `lwf-remote_file` convention already in this file (`">= 1.1.3 < 2.0.1"`). Also bumps `version` to `0.5.11` since `v0.5.10` is burned (GitHub release exists; never published to Forge).

## Test plan

- [ ] Merge.
- [ ] Tag `v0.5.11` at the merge commit — Release workflow should publish `0.5.11` to Puppet Forge cleanly.