### PR TITLE
fix(security): add explicit workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
 
 name: Tests
 
+permissions:
+  contents: read
+
 jobs:
   run_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,15 @@ on:
 
 name: Release
 
+permissions:
+  contents: read
+
 jobs:
   run_prerelease_tasks:
     runs-on: ubuntu-latest
     name: Run tests
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Prepare environment

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,10 +8,16 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Test Default Branch
         id: default-branch

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-newrelic_installer",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "author": "New Relic, Inc.",
   "summary": "Puppet module for installing New Relic integrations",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Resolves the 5 open CodeQL `actions/missing-workflow-permissions` alerts across `main.yml`, `release.yml`, and `repolinter.yml`.

- Each workflow declares `permissions: contents: read` at the top level (minimal default).
- `release.yml` — `run_prerelease_tasks` job: `contents: write` (needed by `actions/create-release@v1`). The other release jobs (`push_to_forge`, `slack-notification`) inherit `contents: read` since they call external APIs (Forge / Slack webhook), not `GITHUB_TOKEN`.
- `repolinter.yml` — `repolint` job: `contents: read` + `issues: write` (the action posts to issues per `output_type: issue`).
- `main.yml` — read-only at workflow level (just runs the test action).

## Test plan

- [ ] CodeQL re-scan closes alerts #1–#5 after merge.
- [ ] Next tag-driven release (`v0.5.12`+) still creates the GitHub Release and pushes to Puppet Forge — proves the per-job permission split is correct.