### PR TITLE
Add idempotency guards to install execs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -97,14 +97,17 @@ class newrelic_installer::install (
         proxy  => $proxy,
       }
       -> exec { 'install newrelic-cli':
-        command     => strip('/tmp/newrelic_cli_install.sh'),
+        creates     => '/usr/local/bin/newrelic',
+        command     => '/tmp/newrelic_cli_install.sh',
+        path        => ['/usr/local/sbin', '/usr/sbin', '/sbin', '/usr/bin', '/bin', '/usr/local/bin'],
         environment => $cli_envars,
         timeout     => $install_timeout_seconds,
         logoutput   => true,
       }
       -> exec { 'install newrelic instrumentation':
-        command     => strip("/usr/local/bin/newrelic install ${cli_recipe_arg} -y ${cli_tag_arg} ${cli_verbosity_arg}")
-        ,
+        unless      => '/usr/bin/test -f /etc/newrelic-infra.yml',
+        command     => strip("/usr/local/bin/newrelic install ${cli_recipe_arg} -y ${cli_tag_arg} ${cli_verbosity_arg}"),
+        path        => ['/usr/local/sbin', '/usr/sbin', '/sbin', '/usr/bin', '/bin', '/usr/local/bin'],
         environment => $cli_envars,
         timeout     => $install_timeout_seconds,
         logoutput   => true,
@@ -118,13 +121,15 @@ class newrelic_installer::install (
         proxy  => $proxy,
       }
       -> exec { 'install newrelic-cli':
-        command     => strip('powershell -ExecutionPolicy Bypass -File C:\Windows\TEMP\install.ps1'),
+        creates     => 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe',
+        command     => 'powershell -ExecutionPolicy Bypass -File C:\Windows\TEMP\install.ps1',
         provider    => powershell,
         environment => $cli_envars,
         timeout     => $install_timeout_seconds,
         logoutput   => true,
       }
       -> exec { 'install newrelic instrumentation':
+        unless      => 'powershell -Command "if (Test-Path \"C:\Program Files\New Relic\New Relic Infrastructure\newrelic-infra.yml\") { exit 0 } else { exit 1 }"',
         command     => strip("\"C:\\Program Files\\New Relic\\New Relic CLI\\newrelic.exe\" install ${cli_recipe_arg} -y ${cli_tag_arg} ${cli_verbosity_arg}"),
         environment => $cli_envars,
         timeout     => $install_timeout_seconds,


### PR DESCRIPTION
## What

Adds `creates`/`unless` guards (and an explicit `path`) to the `install newrelic-cli` and `install newrelic instrumentation` `exec` resources in `manifests/install.pp`, for both the Linux and Windows branches.

## Why

Neither exec currently has a `creates`, `unless`, or `onlyif` guard, so both run unconditionally on every Puppet agent run once the class is applied - even when New Relic is already fully installed. With `logoutput => true` this means every converge re-downloads the CLI installer, re-runs the instrumentation installer, and logs the full (multi-line, ASCII-art-banner-included) installer output, on every run, forever.

- `install newrelic-cli` now has `creates => '/usr/local/bin/newrelic'` (Linux) / `creates => 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe'` (Windows), so it only runs if the CLI binary isn't already present.
- `install newrelic instrumentation` now has `unless` guards that check for the resulting agent config (`/etc/newrelic-infra.yml` on Linux, the Windows Infrastructure agent's `newrelic-infra.yml` equivalent), so it only runs if instrumentation hasn't actually been installed yet.
- Added an explicit `path` on the Linux execs, since the shell provider's PATH lookup for the installed binaries isn't otherwise guaranteed by the agent's environment.

This directly reproduces and fixes what's described in #32 - applying the class and running `puppet agent -t` repeatedly currently shows both execs "executed successfully (corrective)" on every run.

## Context

Found this while vendoring/upgrading this module for a ~250-node Puppet fleet; wanted idempotent converges without needing a local fork.

## Testing

- `puppet parser validate manifests/install.pp` passes clean (no warnings) before and after.
- Manually diffed against the existing `spec/classes/install_spec.rb` assertions - all of them match on `command` content via regex, which is unchanged, so they should still pass. I didn't have a working `bundle`/rspec-puppet environment to run the full spec suite locally, so please let the CI matrix confirm.
- Diff is intentionally minimal/behavioral-only: no reformatting beyond what's needed to add the guards (I did also fix the pre-existing stray trailing comma after the first Linux `strip(...)` call while touching that line).

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)